### PR TITLE
Implement progressive AFK warnings and kicking

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -3,7 +3,11 @@ SentryDsn = '' # DSN for Sentry.
 LogLevel = 'debug' # Log level.
 ServerPath = 'resources/servers' # Path to the servers folder.
 LocalePath = 'resources/locales' # Path to the locales folder.
-AFKTimeout = "10m" # The duration for a player to be considered afk.
+AFKTimeout = "10m" # Idle duration at which a player becomes eligible to be kicked for AFK.
+AFKWarnApproaching = "4m" # Idle duration at which players get a soft "AFK in 1 minute" warning (always sent).
+AFKMarkAFK = "5m" # Idle duration at which players are told they are now AFK (always sent).
+AFKFinalWarning = "9m" # Idle duration at which players get the near-capacity hard warning (only when over threshold).
+AFKFullnessThreshold = 0.90 # Fraction (0..1) of MaxCount at/above which AFK players start getting kicked, longest-AFK first.
 
 [Network]
 Address = ':19132' # Address to bind to.

--- a/pokebedrock/config.go
+++ b/pokebedrock/config.go
@@ -15,12 +15,16 @@ import (
 
 const (
 	// Default timeout and duration constants
-	defaultAFKTimeout      = 10 * time.Minute
-	defaultMaxWaitTime     = 10 * time.Minute
-	defaultBackoffInterval = 1 * time.Minute
-	defaultQueueTimeout    = 15 * time.Minute
-	defaultMaxRestartTime  = 20 * time.Minute
-	defaultRestartCooldown = 5 * time.Minute
+	defaultAFKTimeout         = 10 * time.Minute
+	defaultAFKWarnApproaching = 4 * time.Minute
+	defaultAFKMarkAFK         = 5 * time.Minute
+	defaultAFKFinalWarning    = 9 * time.Minute
+	defaultAFKFullnessThresh  = 0.90
+	defaultMaxWaitTime        = 10 * time.Minute
+	defaultBackoffInterval    = 1 * time.Minute
+	defaultQueueTimeout       = 15 * time.Minute
+	defaultMaxRestartTime     = 20 * time.Minute
+	defaultRestartCooldown    = 5 * time.Minute
 
 	defaultParkourCountdownSeconds = 5
 	defaultParkourCompletionRadius = 1.25
@@ -33,7 +37,24 @@ type Config struct {
 		LogLevel   string // Can be "debug", "info", "warn", "error"
 		ServerPath string
 		LocalePath string
+		// AFKTimeout is how long a player must be idle before becoming
+		// eligible to be kicked for being AFK. The kick itself only fires
+		// when the hub is at or above AFKFullnessThreshold full.
 		AFKTimeout util.Duration
+		// AFKWarnApproaching is how long a player must be idle before
+		// receiving the "AFK in 1 minute" soft warning. Always sent.
+		AFKWarnApproaching util.Duration
+		// AFKMarkAFK is how long a player must be idle before being told
+		// they are now AFK. Always sent.
+		AFKMarkAFK util.Duration
+		// AFKFinalWarning is how long a player must be idle before
+		// receiving the near-capacity hard warning. Only sent when fullness
+		// >= AFKFullnessThreshold.
+		AFKFinalWarning util.Duration
+		// AFKFullnessThreshold is the fraction (0..1) of the hub's MaxCount
+		// at or above which AFK players will start getting kicked,
+		// longest-AFK first.
+		AFKFullnessThreshold float64
 	}
 	Service struct {
 		GinAddress           string
@@ -93,6 +114,10 @@ func DefaultConfig() Config {
 	c.PokeBedrock.LogLevel = "info" // Default to info level in production
 	c.PokeBedrock.ServerPath = "resources/servers"
 	c.PokeBedrock.AFKTimeout = util.Duration(defaultAFKTimeout)
+	c.PokeBedrock.AFKWarnApproaching = util.Duration(defaultAFKWarnApproaching)
+	c.PokeBedrock.AFKMarkAFK = util.Duration(defaultAFKMarkAFK)
+	c.PokeBedrock.AFKFinalWarning = util.Duration(defaultAFKFinalWarning)
+	c.PokeBedrock.AFKFullnessThreshold = defaultAFKFullnessThresh
 
 	c.Service.GinAddress = ":8080"
 

--- a/pokebedrock/pokebedrock.go
+++ b/pokebedrock/pokebedrock.go
@@ -6,6 +6,7 @@ package pokebedrock
 import (
 	"log/slog"
 	"net/http"
+	"sort"
 	"time"
 
 	"github.com/df-mc/dragonfly/server"
@@ -490,20 +491,87 @@ func (poke *PokeBedrock) World() *world.World {
 	return poke.srv.World()
 }
 
-// doAFKCheck ...
-func (poke *PokeBedrock) doAFKCheck(tx *world.Tx) {
-	for ent := range tx.Players() {
-		p := ent.(*player.Player)
+// afkCandidate pairs a player with their handler's movement tracker and their
+// current idle duration so the evaluator can sort and filter without
+// re-reading state more than once.
+type afkCandidate struct {
+	p   *player.Player
+	m   *session.Movement
+	dur time.Duration
+}
 
+// doAFKCheck sends progressive AFK warnings and, when the hub is near
+// capacity, kicks the longest-AFK players first until fullness drops below
+// the configured threshold. Soft warnings fire regardless of fullness; only
+// the final warning and the actual kicks are gated on fullness.
+func (poke *PokeBedrock) doAFKCheck(tx *world.Tx) {
+	cfg := poke.conf.PokeBedrock
+
+	var cands []afkCandidate
+	for ent := range tx.Players() {
+		p, ok := ent.(*player.Player)
+		if !ok {
+			continue
+		}
 		h, ok := p.Handler().(*handler.PlayerHandler)
 		if !ok {
 			continue
 		}
-
 		m := h.Movement()
-		if time.Since(m.LastMoveTime()) > time.Duration(poke.conf.PokeBedrock.AFKTimeout) {
-			p.Disconnect(text.Colourf("<red>You've been kicked for being AFK.</red>"))
+		cands = append(cands, afkCandidate{p: p, m: m, dur: time.Since(m.LastMoveTime())})
+	}
+	if len(cands) == 0 {
+		return
+	}
+
+	// Soft warnings always fire. Flags are reset on movement so they re-arm
+	// once a player comes back and goes idle again.
+	for _, c := range cands {
+		if c.dur >= time.Duration(cfg.AFKWarnApproaching) && !c.m.WarnedApproaching() {
+			c.p.Message(text.Colourf("<yellow>You will be marked AFK in 1 minute. Move to reset your timer.</yellow>"))
+			c.m.SetWarnedApproaching(true)
 		}
+		if c.dur >= time.Duration(cfg.AFKMarkAFK) && !c.m.MarkedAFK() {
+			c.p.Message(text.Colourf("<gold>You are now AFK. Move to reset your timer.</gold>"))
+			c.m.SetMarkedAFK(true)
+		}
+	}
+
+	maxPlayers := poke.conf.UserConfig.Players.MaxCount
+	if maxPlayers <= 0 {
+		return
+	}
+	fullness := float64(len(cands)) / float64(maxPlayers)
+	if fullness < cfg.AFKFullnessThreshold {
+		return
+	}
+
+	for _, c := range cands {
+		if c.dur >= time.Duration(cfg.AFKFinalWarning) && !c.m.WarnedFinal() {
+			c.p.Message(text.Colourf("<red>Server is near capacity. Move now or you will be kicked for being AFK.</red>"))
+			c.m.SetWarnedFinal(true)
+		}
+	}
+
+	eligible := cands[:0:0]
+	for _, c := range cands {
+		if c.dur >= time.Duration(cfg.AFKTimeout) {
+			eligible = append(eligible, c)
+		}
+	}
+	if len(eligible) == 0 {
+		return
+	}
+	sort.Slice(eligible, func(i, j int) bool { return eligible[i].dur > eligible[j].dur })
+
+	thresholdCount := int(float64(maxPlayers) * cfg.AFKFullnessThreshold)
+	remaining := len(cands)
+	for _, c := range eligible {
+		if remaining < thresholdCount {
+			return
+		}
+		c.p.Disconnect(text.Colourf("<red>You've been kicked for being AFK.</red>"))
+		remaining--
 	}
 }
 

--- a/pokebedrock/session/movement.go
+++ b/pokebedrock/session/movement.go
@@ -9,12 +9,18 @@ import (
 )
 
 // Movement provides tracking of a player’s last move time,
-// position, yaw, and pitch.
+// position, yaw, and pitch, along with per-idle-streak AFK warning flags
+// consumed by the hub's AFK evaluator.
 type Movement struct {
 	lastMoveTime time.Time
 	lastPosition mgl64.Vec3
 	lastRotation cube.Rotation
-	mu           sync.RWMutex
+
+	warnedApproaching bool
+	markedAFK         bool
+	warnedFinal       bool
+
+	mu sync.RWMutex
 }
 
 // NewMovement creates a new instance of Movement.
@@ -34,10 +40,59 @@ func (m *Movement) LastMoveTime() time.Time {
 	return m.lastMoveTime
 }
 
-// SetLastMoveTime updates the time of the last movement.
+// SetLastMoveTime updates the time of the last movement. Warning flags are
+// reset so the next idle streak starts from scratch.
 func (m *Movement) SetLastMoveTime(t time.Time) {
 	m.mu.Lock()
 	m.lastMoveTime = t
+	m.warnedApproaching = false
+	m.markedAFK = false
+	m.warnedFinal = false
+	m.mu.Unlock()
+}
+
+// WarnedApproaching reports whether the approaching-AFK soft warning has
+// already been sent for the current idle streak.
+func (m *Movement) WarnedApproaching() bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.warnedApproaching
+}
+
+// SetWarnedApproaching marks the approaching-AFK soft warning as sent.
+func (m *Movement) SetWarnedApproaching(v bool) {
+	m.mu.Lock()
+	m.warnedApproaching = v
+	m.mu.Unlock()
+}
+
+// MarkedAFK reports whether the "you are now AFK" soft warning has already
+// been sent for the current idle streak.
+func (m *Movement) MarkedAFK() bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.markedAFK
+}
+
+// SetMarkedAFK marks the "you are now AFK" soft warning as sent.
+func (m *Movement) SetMarkedAFK(v bool) {
+	m.mu.Lock()
+	m.markedAFK = v
+	m.mu.Unlock()
+}
+
+// WarnedFinal reports whether the near-capacity final warning has already
+// been sent for the current idle streak.
+func (m *Movement) WarnedFinal() bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.warnedFinal
+}
+
+// SetWarnedFinal marks the near-capacity final warning as sent.
+func (m *Movement) SetWarnedFinal(v bool) {
+	m.mu.Lock()
+	m.warnedFinal = v
 	m.mu.Unlock()
 }
 


### PR DESCRIPTION
Add progressive AFK behavior and configuration: new config options (AFKWarnApproaching, AFKMarkAFK, AFKFinalWarning, AFKFullnessThreshold) were added to config.example.toml and wired into the Config defaults. Movement tracking gained per-idle-streak flags (warnedApproaching, markedAFK, warnedFinal) with getters/setters and reset on movement. The AFK evaluator now issues soft warnings unconditionally, sends a near-capacity final warning when hub fullness >= AFKFullnessThreshold, and when needed kicks eligible AFK players (longest-idle first) until fullness drops below the threshold. Misc: added sorting import and small refactors to support the new logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * AFK system now sends staged warnings ("approaching timeout," "marked AFK," "final warning") before removing idle players.
  * AFK removals trigger dynamically based on server capacity threshold rather than timeout alone.

* **Configuration**
  * Added configurable timing parameters for each AFK warning stage.
  * New server fullness fraction threshold controls when AFK enforcement activates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->