### PR TITLE
feat(hub): poll remote API for beta/dev servers

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -61,6 +61,13 @@ GoroutineThreshold = 800 # Goroutine count at/above which an alert is raised.
 HeapAllocThresholdBytes = 2147483648 # Heap bytes at/above which an alert is raised (2 GiB). 0 disables the heap probe.
 AlertCooldown = "5m" # Minimum time between repeat Sentry alerts for the same condition.
 
+[DevServers]
+Enabled = false # Poll remote manager and expose beta/PR servers in Beta Navigator.
+URL = '' # Manager API base, e.g. https://dev.pokebedrock.com
+Token = '' # Sent as the authorization header on GET /dev-servers
+Host = '' # Public IP/host the managed servers listen on, e.g. 198.244.176.51
+PollIntervalSeconds = 10 # How often to refresh the dynamic server list
+
 [Ranks]
 # Discord Role IDs for different ranks
 TrainerRoleID = "xxxxxxxxxxxxxxxxxxxxx"

--- a/pokebedrock/config.go
+++ b/pokebedrock/config.go
@@ -35,6 +35,8 @@ const (
 	defaultWatchdogGoroutineThreshold = 800
 	defaultWatchdogHeapAllocThreshold = 2 << 30 // 2 GiB
 	defaultWatchdogAlertCooldown      = 5 * time.Minute
+
+	defaultDevServersPollIntervalSeconds = 10
 )
 
 // Config holds the server configuration, including paths, translations, and service-related settings.
@@ -135,6 +137,18 @@ type Config struct {
 		ManagerRoleID              string
 		OwnerRoleID                string
 	}
+	DevServers struct {
+		// Enabled turns on polling the remote manager for beta/dev servers.
+		Enabled bool
+		// URL is the manager API base (e.g. https://dev.pokebedrock.com).
+		URL string
+		// Token is sent as the authorization header.
+		Token string
+		// Host is the public IP/host the managed servers listen on.
+		Host string
+		// PollIntervalSeconds is how often to GET /dev-servers.
+		PollIntervalSeconds int
+	}
 	server.UserConfig
 }
 
@@ -181,6 +195,12 @@ func DefaultConfig() Config {
 	c.Watchdog.GoroutineThreshold = defaultWatchdogGoroutineThreshold
 	c.Watchdog.HeapAllocThresholdBytes = defaultWatchdogHeapAllocThreshold
 	c.Watchdog.AlertCooldown = util.Duration(defaultWatchdogAlertCooldown)
+
+	c.DevServers.Enabled = false
+	c.DevServers.URL = ""
+	c.DevServers.Token = ""
+	c.DevServers.Host = ""
+	c.DevServers.PollIntervalSeconds = defaultDevServersPollIntervalSeconds
 
 	userConfig := server.DefaultConfig()
 	userConfig.Server.Name = text.Colourf("<red>Poke</red><aqua>Bedrock</aqua>")
@@ -251,6 +271,9 @@ func ReadConfig() (Config, error) {
 	}
 	if conf.Watchdog.HeapAllocThresholdBytes == 0 {
 		conf.Watchdog.HeapAllocThresholdBytes = defaults.Watchdog.HeapAllocThresholdBytes
+	}
+	if conf.DevServers.PollIntervalSeconds == 0 {
+		conf.DevServers.PollIntervalSeconds = defaults.DevServers.PollIntervalSeconds
 	}
 
 	return conf, nil

--- a/pokebedrock/devserver/diff_test.go
+++ b/pokebedrock/devserver/diff_test.go
@@ -1,0 +1,116 @@
+package devserver
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/smell-of-curry/pokebedrock-hub/pokebedrock/srv"
+)
+
+func TestDiffRegisterUnregisterAndUpdate(t *testing.T) {
+	pr := 123
+	desired, err := DesiredConfigs([]APIServer{
+		{Name: "BETA", Type: "beta", Port: 19200, Status: "running"},
+		{Name: "PR-123", Type: "pr", PRNumber: &pr, Branch: "feature/x", Port: 19204, Status: "running"},
+		{Name: "PR-999", Type: "pr", PRNumber: intPtr(999), Port: 19205, Status: "stopping"},
+	}, "198.244.176.51")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	current := map[string]Snapshot{
+		"dev-beta":   {Name: "BETA", Address: "198.244.176.51:19200"},
+		"dev-pr-50":  {Name: "PR-50 (old)", Address: "198.244.176.51:19201"},
+		"dev-pr-123": {Name: "PR-123 (old)", Address: "198.244.176.51:19204"},
+	}
+
+	register, unregister := Diff(current, desired)
+	sort.Strings(unregister)
+	sort.Slice(register, func(i, j int) bool {
+		return register[i].Identifier < register[j].Identifier
+	})
+
+	if !reflect.DeepEqual(unregister, []string{"dev-pr-50"}) {
+		t.Fatalf("unregister = %v, want [dev-pr-50]", unregister)
+	}
+	if len(register) != 1 {
+		t.Fatalf("register len = %d, want 1 (name change for pr-123)", len(register))
+	}
+	if register[0].Identifier != "dev-pr-123" {
+		t.Fatalf("register[0] = %s, want dev-pr-123", register[0].Identifier)
+	}
+	if register[0].Name != "PR-123 (feature/x)" {
+		t.Fatalf("register name = %q", register[0].Name)
+	}
+	if !register[0].BetaLock {
+		t.Fatal("expected BetaLock")
+	}
+}
+
+func TestDiffEmptyCurrentRegistersAllRunning(t *testing.T) {
+	desired, err := DesiredConfigs([]APIServer{
+		{Name: "BETA", Type: "beta", Port: 19200, Status: "running"},
+	}, "10.0.0.1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	register, unregister := Diff(nil, desired)
+	if len(unregister) != 0 {
+		t.Fatalf("unregister = %v, want none", unregister)
+	}
+	if len(register) != 1 || register[0].Identifier != "dev-beta" {
+		t.Fatalf("register = %+v", register)
+	}
+	if register[0].Address != "10.0.0.1:19200" {
+		t.Fatalf("address = %s", register[0].Address)
+	}
+}
+
+func TestDesiredConfigsFiltersNonRunning(t *testing.T) {
+	desired, err := DesiredConfigs([]APIServer{
+		{Name: "BETA", Type: "beta", Port: 1, Status: "running"},
+		{Name: "GONE", Type: "beta", Port: 2, Status: "stopped"},
+	}, "h")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(desired) != 1 {
+		t.Fatalf("desired len = %d", len(desired))
+	}
+	if _, ok := desired["dev-beta"]; !ok {
+		t.Fatal("missing dev-beta")
+	}
+}
+
+func TestDecodeResponse(t *testing.T) {
+	raw := []byte(`{"servers":[{"name":"BETA","type":"beta","prNumber":null,"branch":"main","port":19200,"maxPlayers":40,"status":"running"},{"name":"PR-123","type":"pr","prNumber":123,"branch":"feature/x","port":19204,"maxPlayers":20,"status":"running"}]}`)
+	resp, err := DecodeResponse(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Servers) != 2 {
+		t.Fatalf("len = %d", len(resp.Servers))
+	}
+	if resp.Servers[0].Name != "BETA" || resp.Servers[0].Port != 19200 {
+		t.Fatalf("beta = %+v", resp.Servers[0])
+	}
+	if resp.Servers[1].PRNumber == nil || *resp.Servers[1].PRNumber != 123 {
+		t.Fatalf("pr = %+v", resp.Servers[1])
+	}
+}
+
+func TestDiffNoChangeWhenIdentical(t *testing.T) {
+	cfg := srv.Config{
+		Name: "BETA", Identifier: "dev-beta", Address: "h:1", BetaLock: true,
+	}
+	register, unregister := Diff(
+		map[string]Snapshot{"dev-beta": {Name: "BETA", Address: "h:1"}},
+		map[string]srv.Config{"dev-beta": cfg},
+	)
+	if len(register) != 0 || len(unregister) != 0 {
+		t.Fatalf("register=%v unregister=%v", register, unregister)
+	}
+}
+
+func intPtr(v int) *int { return &v }

--- a/pokebedrock/devserver/service.go
+++ b/pokebedrock/devserver/service.go
@@ -1,0 +1,188 @@
+package devserver
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/smell-of-curry/pokebedrock-hub/pokebedrock/srv"
+)
+
+const (
+	requestTimeout = 5 * time.Second
+	defaultPoll    = 10 * time.Second
+)
+
+// Config holds DevServers settings from config.toml.
+type Config struct {
+	Enabled             bool
+	URL                 string
+	Token               string
+	Host                string
+	PollIntervalSeconds int
+}
+
+// Service polls the remote manager and syncs `dev-` servers into the registry.
+type Service struct {
+	cfg    Config
+	client *http.Client
+	log    *slog.Logger
+
+	stopOnce sync.Once
+	stop     chan struct{}
+	done     chan struct{}
+}
+
+var (
+	globalService *Service
+	globalMu      sync.RWMutex
+)
+
+// GlobalService returns the singleton poller, or nil if not started.
+func GlobalService() *Service {
+	globalMu.RLock()
+	defer globalMu.RUnlock()
+	return globalService
+}
+
+// NewService creates and starts the poller when Enabled and required fields are set.
+func NewService(log *slog.Logger, cfg Config) *Service {
+	if !cfg.Enabled {
+		return nil
+	}
+	if cfg.URL == "" || cfg.Token == "" || cfg.Host == "" {
+		log.Warn("dev servers enabled but URL/Token/Host incomplete; poller not started")
+		return nil
+	}
+
+	interval := time.Duration(cfg.PollIntervalSeconds) * time.Second
+	if interval <= 0 {
+		interval = defaultPoll
+	}
+	cfg.PollIntervalSeconds = int(interval / time.Second)
+
+	s := &Service{
+		cfg: cfg,
+		client: &http.Client{
+			Timeout: requestTimeout,
+		},
+		log:  log,
+		stop: make(chan struct{}),
+		done: make(chan struct{}),
+	}
+
+	globalMu.Lock()
+	globalService = s
+	globalMu.Unlock()
+
+	go s.loop(interval)
+	return s
+}
+
+// Stop ends the poll loop. Safe to call on nil.
+func (s *Service) Stop() {
+	if s == nil {
+		return
+	}
+	s.stopOnce.Do(func() {
+		close(s.stop)
+	})
+	select {
+	case <-s.done:
+	case <-time.After(3 * time.Second):
+	}
+}
+
+func (s *Service) loop(interval time.Duration) {
+	defer close(s.done)
+
+	s.pollOnce()
+
+	t := time.NewTicker(interval)
+	defer t.Stop()
+
+	for {
+		select {
+		case <-s.stop:
+			return
+		case <-t.C:
+			s.pollOnce()
+		}
+	}
+}
+
+func (s *Service) pollOnce() {
+	resp, err := s.fetch()
+	if err != nil {
+		s.log.Warn("dev servers poll failed; keeping current set", "error", err)
+		return
+	}
+
+	desired, err := DesiredConfigs(resp.Servers, s.cfg.Host)
+	if err != nil {
+		s.log.Warn("dev servers response invalid; keeping current set", "error", err)
+		return
+	}
+
+	current := currentDevSnapshots()
+	register, unregister := Diff(current, desired)
+
+	for _, id := range unregister {
+		srv.Unregister(id)
+		s.log.Info("unregistered dev server", "identifier", id)
+	}
+	for _, cfg := range register {
+		srv.Register(srv.NewServer(s.log, cfg))
+		s.log.Info("registered dev server", "identifier", cfg.Identifier, "name", cfg.Name, "address", cfg.Address)
+	}
+}
+
+func (s *Service) fetch() (APIResponse, error) {
+	base := strings.TrimRight(s.cfg.URL, "/")
+	url := base + "/dev-servers"
+
+	ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return APIResponse{}, fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("authorization", s.cfg.Token)
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return APIResponse{}, fmt.Errorf("request failed: %w", err)
+	}
+	defer func() {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+	}()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return APIResponse{}, fmt.Errorf("read response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return APIResponse{}, fmt.Errorf("unexpected status %d", resp.StatusCode)
+	}
+	return DecodeResponse(body)
+}
+
+func currentDevSnapshots() map[string]Snapshot {
+	out := make(map[string]Snapshot)
+	for _, s := range srv.All() {
+		id := s.Identifier()
+		if !IsDevIdentifier(id) {
+			continue
+		}
+		cfg := s.Config()
+		out[id] = Snapshot{Name: cfg.Name, Address: cfg.Address}
+	}
+	return out
+}

--- a/pokebedrock/devserver/types.go
+++ b/pokebedrock/devserver/types.go
@@ -1,0 +1,113 @@
+package devserver
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+
+	"github.com/smell-of-curry/pokebedrock-hub/pokebedrock/srv"
+)
+
+// IdentifierPrefix marks dynamically registered beta/dev servers.
+const IdentifierPrefix = "dev-"
+
+// APIResponse is the JSON body from GET /dev-servers.
+type APIResponse struct {
+	Servers []APIServer `json:"servers"`
+}
+
+// APIServer is one entry from the remote manager API.
+type APIServer struct {
+	Name       string `json:"name"`
+	Type       string `json:"type"`
+	PRNumber   *int   `json:"prNumber"`
+	Branch     string `json:"branch"`
+	Port       int    `json:"port"`
+	MaxPlayers int    `json:"maxPlayers"`
+	Status     string `json:"status"`
+}
+
+// Snapshot is the comparable view of a currently registered dev server.
+type Snapshot struct {
+	Name    string
+	Address string
+}
+
+// DecodeResponse parses a /dev-servers JSON payload.
+func DecodeResponse(data []byte) (APIResponse, error) {
+	var resp APIResponse
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return APIResponse{}, fmt.Errorf("decode dev-servers response: %w", err)
+	}
+	return resp, nil
+}
+
+// IdentifierFor returns the registry identifier for an API server entry.
+func IdentifierFor(s APIServer) (string, error) {
+	switch strings.ToLower(s.Type) {
+	case "beta":
+		return IdentifierPrefix + "beta", nil
+	case "pr":
+		if s.PRNumber == nil {
+			return "", fmt.Errorf("pr server %q missing prNumber", s.Name)
+		}
+		return fmt.Sprintf("%spr-%d", IdentifierPrefix, *s.PRNumber), nil
+	default:
+		return "", fmt.Errorf("unknown server type %q", s.Type)
+	}
+}
+
+// DisplayName returns the hub-facing server name.
+func DisplayName(s APIServer) string {
+	if strings.EqualFold(s.Type, "pr") && s.Branch != "" {
+		return fmt.Sprintf("%s (%s)", s.Name, s.Branch)
+	}
+	return s.Name
+}
+
+// DesiredConfigs builds registry configs for running API servers on host.
+// Non-running entries are omitted (treated as gone).
+func DesiredConfigs(servers []APIServer, host string) (map[string]srv.Config, error) {
+	desired := make(map[string]srv.Config, len(servers))
+	for _, s := range servers {
+		if !strings.EqualFold(s.Status, "running") {
+			continue
+		}
+		id, err := IdentifierFor(s)
+		if err != nil {
+			return nil, err
+		}
+		desired[id] = srv.Config{
+			Name:       DisplayName(s),
+			Identifier: id,
+			Address:    net.JoinHostPort(host, strconv.Itoa(s.Port)),
+			BetaLock:   true,
+		}
+	}
+	return desired, nil
+}
+
+// Diff computes register/unregister ops between current and desired dev servers.
+// Only identifiers present in current/desired are considered; callers must pass
+// only IdentifierPrefix entries as current.
+func Diff(current map[string]Snapshot, desired map[string]srv.Config) (register []srv.Config, unregister []string) {
+	for id := range current {
+		if _, ok := desired[id]; !ok {
+			unregister = append(unregister, id)
+		}
+	}
+	for id, cfg := range desired {
+		cur, ok := current[id]
+		if !ok || cur.Name != cfg.Name || cur.Address != cfg.Address {
+			register = append(register, cfg)
+		}
+	}
+	return register, unregister
+}
+
+// IsDevIdentifier reports whether id belongs to the dynamic dev registry.
+func IsDevIdentifier(id string) bool {
+	return strings.HasPrefix(id, IdentifierPrefix)
+}

--- a/pokebedrock/form/beta_navigator.go
+++ b/pokebedrock/form/beta_navigator.go
@@ -1,0 +1,89 @@
+package form
+
+import (
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/df-mc/dragonfly/server/player"
+	"github.com/df-mc/dragonfly/server/player/form"
+	"github.com/df-mc/dragonfly/server/world"
+	"github.com/sandertv/gophertunnel/minecraft/text"
+
+	"github.com/smell-of-curry/pokebedrock-hub/pokebedrock/devserver"
+	"github.com/smell-of-curry/pokebedrock-hub/pokebedrock/srv"
+)
+
+// betaNavigator lists dynamically registered dev-/beta servers.
+type betaNavigator struct{}
+
+// NewBetaNavigator ...
+func NewBetaNavigator() form.Menu {
+	f := form.NewMenu(betaNavigator{}, text.Colourf("Beta Navigator"))
+
+	servers := devServers()
+	if len(servers) == 0 {
+		return f.WithBody(text.Colourf("<grey>No dev servers online.</grey>")).
+			WithButtons(form.NewButton(text.Colourf("<grey>None available</grey>"), ""))
+	}
+
+	btns := make([]form.Button, 0, len(servers))
+	for _, s := range servers {
+		st := s.Status()
+
+		var statusName string
+		if st.Online {
+			statusName = "<green>Online</green>"
+		} else {
+			statusName = "<dark-red>Offline</dark-red>"
+		}
+
+		name := text.Colourf("%s\n%s (%d<b>/</b>%d)", s.Name(), statusName, st.PlayerCount, st.MaxPlayerCount)
+		btns = append(btns, form.NewButton(name, s.Icon()))
+	}
+
+	return f.WithButtons(btns...)
+}
+
+// Submit ...
+func (betaNavigator) Submit(sub form.Submitter, b form.Button, _ *world.Tx) {
+	p := sub.(*player.Player)
+	serverName := text.Clean(strings.Split(b.Text, "\n")[0])
+	server := srv.FromName(serverName)
+
+	if server == nil || !devserver.IsDevIdentifier(server.Identifier()) {
+		p.Message(text.Colourf("<dark-red>Failed to find server with name %s.</dark-red>", serverName))
+		return
+	}
+
+	p.SendForm(NewServerConfirm(server))
+}
+
+func devServers() []*srv.Server {
+	var out []*srv.Server
+	for _, s := range srv.All() {
+		if devserver.IsDevIdentifier(s.Identifier()) {
+			out = append(out, s)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		ii, jj := out[i].Identifier(), out[j].Identifier()
+		if ii == "dev-beta" {
+			return true
+		}
+		if jj == "dev-beta" {
+			return false
+		}
+		return prNumber(ii) < prNumber(jj)
+	})
+	return out
+}
+
+func prNumber(id string) int {
+	const prefix = "dev-pr-"
+	if !strings.HasPrefix(id, prefix) {
+		return 0
+	}
+	n, _ := strconv.Atoi(strings.TrimPrefix(id, prefix))
+	return n
+}

--- a/pokebedrock/form/server_confirm.go
+++ b/pokebedrock/form/server_confirm.go
@@ -56,7 +56,7 @@ func (f ServerConfirm) Submit(sub form.Submitter, b form.Button, _ *world.Tx) {
 	}
 
 	// Check if beta lock is enabled, if so, only Supporters and staff can join
-	if cfg.BetaLock && !(h.Ranks().HasRank(rank.Supporter) || highestRank >= rank.Moderator) {
+	if cfg.BetaLock && !rank.CanAccessBeta(h.Ranks().Ranks()) {
 		p.Message(locale.Translate("queue.beta.lock"))
 
 		return

--- a/pokebedrock/form/server_navigator.go
+++ b/pokebedrock/form/server_navigator.go
@@ -8,6 +8,7 @@ import (
 	"github.com/df-mc/dragonfly/server/world"
 	"github.com/sandertv/gophertunnel/minecraft/text"
 
+	"github.com/smell-of-curry/pokebedrock-hub/pokebedrock/devserver"
 	"github.com/smell-of-curry/pokebedrock-hub/pokebedrock/srv"
 )
 
@@ -22,6 +23,9 @@ func NewServerNavigator() form.Menu {
 	btns := make([]form.Button, 0, len(srv.All()))
 
 	for _, s := range srv.All() {
+		if devserver.IsDevIdentifier(s.Identifier()) {
+			continue
+		}
 		st := s.Status()
 
 		var statusName string

--- a/pokebedrock/handler/player.go
+++ b/pokebedrock/handler/player.go
@@ -96,6 +96,8 @@ func (h *PlayerHandler) HandleItemUse(ctx *player.Context) {
 		switch action {
 		case "navigator":
 			p.SendForm(form.NewServerNavigator())
+		case "beta-navigator":
+			p.SendForm(form.NewBetaNavigator())
 		case "spawn":
 			w := p.Tx().World()
 			p.Teleport(w.Spawn().Vec3Middle())
@@ -241,6 +243,11 @@ func (h *PlayerHandler) HandleQuit(p *player.Player) {
 // Ranks ...
 func (h *PlayerHandler) Ranks() *session.Ranks {
 	return h.ranks
+}
+
+// CanAccessBeta reports whether this player may use beta/dev servers.
+func (h *PlayerHandler) CanAccessBeta() bool {
+	return rank.CanAccessBeta(h.ranks.Ranks())
 }
 
 // Inflictions ...

--- a/pokebedrock/kit/lobby.go
+++ b/pokebedrock/kit/lobby.go
@@ -15,6 +15,7 @@ const (
 
 	// Lobby-specific constants
 	compassSlot        = 8   // Slot for compass item
+	betaNavigatorSlot  = 5   // Slot for beta navigator (7 is spawn nether star)
 	speedEffectLevel   = 5   // Speed effect level
 	defaultFlightSpeed = 0.2 // Default flight speed
 )
@@ -25,9 +26,14 @@ var Lobby lobby
 // lobby ...
 type lobby struct{}
 
+// betaAccessHandler is implemented by *handler.PlayerHandler.
+type betaAccessHandler interface {
+	CanAccessBeta() bool
+}
+
 // Items ...
-func (lobby) Items(*player.Player) (items [inventorySlots]item.Stack) {
-	return [inventorySlots]item.Stack{
+func (lobby) Items(p *player.Player) (items [inventorySlots]item.Stack) {
+	items = [inventorySlots]item.Stack{
 		0: item.NewStack(item.Spyglass{}, 1).
 			WithCustomName(text.Colourf("<yellow>Toggle Players</yellow>")).
 			WithValue("lobby", "toggle-visibility"),
@@ -41,6 +47,12 @@ func (lobby) Items(*player.Player) (items [inventorySlots]item.Stack) {
 			WithCustomName(text.Colourf("<purple>Server Navigator</purple>")).
 			WithValue("lobby", "navigator"),
 	}
+	if h, ok := p.Handler().(betaAccessHandler); ok && h.CanAccessBeta() {
+		items[betaNavigatorSlot] = item.NewStack(item.RecoveryCompass{}, 1).
+			WithCustomName(text.Colourf("<aqua>Beta Navigator</aqua>")).
+			WithValue("lobby", "beta-navigator")
+	}
+	return items
 }
 
 // ApplyFunc ...

--- a/pokebedrock/pokebedrock.go
+++ b/pokebedrock/pokebedrock.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/smell-of-curry/pokebedrock-hub/pokebedrock/authentication"
 	"github.com/smell-of-curry/pokebedrock-hub/pokebedrock/command"
+	"github.com/smell-of-curry/pokebedrock-hub/pokebedrock/devserver"
 	"github.com/smell-of-curry/pokebedrock-hub/pokebedrock/handler"
 	"github.com/smell-of-curry/pokebedrock-hub/pokebedrock/hider"
 	"github.com/smell-of-curry/pokebedrock-hub/pokebedrock/locale"
@@ -383,6 +384,14 @@ func (poke *PokeBedrock) loadServices() {
 		MaxRestartTime:  time.Duration(poke.conf.RestartManager.MaxRestartTime),
 	}
 	restart.NewService(poke.log, restartConfig)
+
+	devserver.NewService(poke.log, devserver.Config{
+		Enabled:             poke.conf.DevServers.Enabled,
+		URL:                 poke.conf.DevServers.URL,
+		Token:               poke.conf.DevServers.Token,
+		Host:                poke.conf.DevServers.Host,
+		PollIntervalSeconds: poke.conf.DevServers.PollIntervalSeconds,
+	})
 }
 
 // loadServers loads all the server configurations from the specified path
@@ -624,6 +633,9 @@ func (poke *PokeBedrock) Close() {
 
 	poke.log.Debug("Closing Restart Manager Service...")
 	restart.GlobalService().Stop()
+
+	poke.log.Debug("Closing Dev Servers Service...")
+	devserver.GlobalService().Stop()
 
 	poke.log.Debug("Stopping Rank Channel...")
 	session.StopRankChannel()

--- a/pokebedrock/rank/access.go
+++ b/pokebedrock/rank/access.go
@@ -1,0 +1,17 @@
+package rank
+
+// CanAccessBeta reports whether the given ranks may use beta/dev servers.
+// Matches the BetaLock join gate: Supporter (any) or Moderator+.
+func CanAccessBeta(ranks []Rank) bool {
+	var highest Rank
+	hasSupporter := false
+	for _, r := range ranks {
+		if r == Supporter {
+			hasSupporter = true
+		}
+		if r > highest {
+			highest = r
+		}
+	}
+	return hasSupporter || highest >= Moderator
+}

--- a/pokebedrock/rank/access_test.go
+++ b/pokebedrock/rank/access_test.go
@@ -1,0 +1,32 @@
+package rank
+
+import "testing"
+
+func TestCanAccessBeta(t *testing.T) {
+	tests := []struct {
+		name  string
+		ranks []Rank
+		want  bool
+	}{
+		{"empty", nil, false},
+		{"unlinked", []Rank{UnLinked}, false},
+		{"trainer", []Rank{Trainer}, false},
+		{"booster", []Rank{ServerBooster}, false},
+		{"supporter", []Rank{Supporter}, true},
+		{"premium alone", []Rank{Premium}, false},
+		{"helper", []Rank{Helper}, false},
+		{"moderator", []Rank{Moderator}, true},
+		{"admin", []Rank{Admin}, true},
+		{"owner", []Rank{Owner}, true},
+		{"trainer+supporter", []Rank{Trainer, Supporter}, true},
+		{"premium+supporter", []Rank{Premium, Supporter}, true},
+		{"helper+moderator", []Rank{Helper, Moderator}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := CanAccessBeta(tt.ranks); got != tt.want {
+				t.Fatalf("CanAccessBeta(%v) = %v, want %v", tt.ranks, got, tt.want)
+			}
+		})
+	}
+}

--- a/pokebedrock/session/ranks.go
+++ b/pokebedrock/session/ranks.go
@@ -12,6 +12,7 @@ import (
 	"github.com/sandertv/gophertunnel/minecraft/text"
 
 	"github.com/smell-of-curry/pokebedrock-hub/pokebedrock/internal"
+	"github.com/smell-of-curry/pokebedrock-hub/pokebedrock/kit"
 	"github.com/smell-of-curry/pokebedrock-hub/pokebedrock/locale"
 	"github.com/smell-of-curry/pokebedrock-hub/pokebedrock/rank"
 )
@@ -139,7 +140,29 @@ func processRankUpdate(update rankUpdate) {
 		p.SendJukeboxPopup(syncedMsg)
 		p.Message(syncedMsg)
 		p.SetNameTag(highest.NameTag(p.Name()))
+		// Ranks load async after join; re-apply lobby kit so gated items
+		// (Beta Navigator) appear once roles are known. Skip mid-parkour
+		// (avoid session→parkour import cycle; parkour items carry "parkour" NBT).
+		if hasParkourKitItem(p) {
+			return
+		}
+		kit.Apply(kit.Lobby, p)
 	})
+}
+
+// hasParkourKitItem reports whether the player currently holds parkour kit items.
+func hasParkourKitItem(p *player.Player) bool {
+	inv := p.Inventory()
+	for slot, size := 0, inv.Size(); slot < size; slot++ {
+		it, err := inv.Item(slot)
+		if err != nil || it.Empty() {
+			continue
+		}
+		if _, ok := it.Value("parkour"); ok {
+			return true
+		}
+	}
+	return false
 }
 
 // Ranks tracks a player's resolved ranks and the last time they were


### PR DESCRIPTION
Dynamic dev-* registry + gated Beta Navigator item for Supporters/Mod+, shared CanAccessBeta helper.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Beta Navigator for eligible players to browse and select development servers, including live status and capacity details.
  * Added automatic synchronization of available development servers.
  * Added configurable development-server management settings and polling.
  * Beta access is now available to supporters and higher-ranked players.
  * Lobby menus now separate development servers from standard servers.
  * Lobby kits are restored after player ranks load, except when parkour items are equipped.
* **Tests**
  * Added coverage for server synchronization and beta-access rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->